### PR TITLE
Activate Climate Library in PnET-Succession

### DIFF
--- a/src/Names.cs
+++ b/src/Names.cs
@@ -25,6 +25,7 @@ namespace Landis.Extension.Succession.BiomassPnET
         public const string IMAX = "IMAX";
         public const string InitialCommunities = "InitialCommunities";
         public const string InitialCommunitiesMap = "InitialCommunitiesMap";
+        public const string ClimateConfigFile = "ClimateConfigFile";
         public const string MapCoordinates = "MapCoordinates";
         public const string PNEToutputSiteCoordinates = "PNEToutputSiteCoordinates";
         public const string PNEToutputSiteLocation = "PNEToutputSiteLocation";

--- a/src/ParameterTableParser.cs
+++ b/src/ParameterTableParser.cs
@@ -69,6 +69,10 @@ namespace Landis.Extension.Succession.BiomassPnET
                 InputVar<string> landisData = new InputVar<string>("LandisData");
                 ReadVar(landisData);
 
+                InputVar<string> climateConfigFile = new InputVar<string>(Names.ClimateConfigFile);
+                ReadVar(climateConfigFile);
+                parameters.Add(Names.ClimateConfigFile, new Parameter<string>(Names.ClimateConfigFile, climateConfigFile.Value.String));
+
                 if (landisData.Value.Actual != this.KeyWord)
                 {
                     throw new InputValueException(landisData.Value.String, "Landis Keyword expected " + this.KeyWord + " but read \"{0}\"" + this.FileName, landisData.Value.Actual);

--- a/src/PlugIn.cs
+++ b/src/PlugIn.cs
@@ -2,6 +2,7 @@
 //  Authors:  Arjan de Bruijn
 
 using Landis.Core;
+using Landis.Library.Climate;
 using Landis.SpatialModeling;
 using Landis.Library.Succession;
 using Landis.Library.InitialCommunities;
@@ -27,9 +28,10 @@ namespace Landis.Extension.Succession.BiomassPnET
         private static DateTime StartDate;
         private static Dictionary<ActiveSite, string> SiteOutputNames;
         public static ushort IMAX;
+        public static int FutureClimateBaseYear;
         //public static float PrecipEvents;// Now an ecoregion parameter
-        
-        
+
+
         private static SortedDictionary<string, Parameter<string>> parameters = new SortedDictionary<string, Parameter<string>>(StringComparer.InvariantCultureIgnoreCase);
         MyClock m = null;
 
@@ -258,7 +260,10 @@ namespace Landis.Extension.Succession.BiomassPnET
 
             //Latitude = ((Parameter<float>)PlugIn.GetParameter(Names.Latitude, 0, 90)).Value; // Now an ecoregion parameter
 
-            
+            //Initialize climate.
+            Climate.Initialize(parameters[Names.ClimateConfigFile].Value, false, ModelCore);
+            FutureClimateBaseYear = Climate.Future_MonthlyData.Keys.Min();
+
             ObservedClimate.Initialize();
 
             SpeciesPnET = new SpeciesPnET();


### PR DESCRIPTION
Added a few lines which should enable the use of the climate library in
PnET-Succession.