### PR TITLE
quick workaround in MyClock.cs/EstimatedTotalTime (int fn) to avoid divide-by-zero

### DIFF
--- a/src/MyClock.cs
+++ b/src/MyClock.cs
@@ -47,7 +47,11 @@ namespace Landis.Extension.Succession.BiomassPnET
         {
             get
             {
-                int EstimatedTotalTime = (int)Math.Round(100.0 / Progress() * MsToSec((int)sw.ElapsedMilliseconds), 0);
+                // MG20260827 -- avoid divide-by-zero causing potential overflow error 
+                int progress = Progress();
+                int EstimatedTotalTime = 0;
+                if (progress > 0)
+                    EstimatedTotalTime = (int)Math.Round(100.0 / progress * MsToSec((int)sw.ElapsedMilliseconds), 0);
                 return EstimatedTotalTime;
             }
         }


### PR DESCRIPTION
In MyClock.cs, the EstimatedTotalTime function uses Progress() as a divisor, but Progress() = 0 when the simulation process starts up. It should throw an exception for int division by zero, but sometimes does not, instead giving a large negative value. Workaround has the EstimatedTotalTime return 0 when Progress() = 0, otherwise Progress > 0 and EstimatedTotalTime should be calculated without error.